### PR TITLE
Bugfix wsdd args concat

### DIFF
--- a/docker-cmd.sh
+++ b/docker-cmd.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 
-args=( )
+args=
 
 if [ ! -z "${HOSTNAME}" ]; then
-	args+=( "-n $HOSTNAME ")
+	args+="-n $HOSTNAME "
 else 
 	echo "HOSTNAME environment variable must be set."
 	exit 1
 fi
 
 if  [ ! -z "${WORKGROUP}" ]; then
-	args+=( "-w $WORKGROUP " )
+	args+="-w $WORKGROUP "
 fi
 
 if  [ ! -z "${DOMAIN}" ]; then
-	args+=( "-d $DOMAIN " )
+	args+="-d $DOMAIN "
 fi
 
 


### PR DESCRIPTION
Using brackets in string concatenation has special meaning
for for bash thus later arguments never gets appended. Use
simple strings concat instead fixes problem.